### PR TITLE
Add tagbot

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,31 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      lookback:
+        default: "3"
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.TAGBOT_PRIV }}

--- a/docs/src/dev_guide.md
+++ b/docs/src/dev_guide.md
@@ -41,9 +41,8 @@ With this issue, we keep track of the workflow for version `<version>` release.
 
 - [ ] Open a PR for merging `release-<version>` into the `main`-branch of the QEDjl-project repository with at least one reviewer who only needs to check the points above, the code additions were reviewed in the respective PRs. Do not delete the `release-<version>` branch yet. :warning: **Do not squash this PR, use a simple merge commit** :warning:
 - [ ] *After* the release branch is merged into `main`, open another PR for merging `release-<version>` into the `dev`-branch of the QEDjl-project repository. This can be merged without much review because the relevant changes were already reviewed in the PR `release-<version> -> main`. After this merge, you are free to delete the `release-<version>`-branch on your fork. :warning: **Do not squash this PR, use a simple merge commit** :warning:
-- [ ] Registration: Go to the issues and search for `Release`. There, write a comment with `<at>JuliaRegistrator register(branch="main")` with a real `@` to trigger the registration bot opening a PR on Julia's general registry. 
-- [ ] *After* the registration bot reports back the correct registration, tag the HEAD of `main` (which should still be the merge commit from the release branch merge) with `v<version>`. This will trigger a new deployment of the stable docs for the new version.
-- [ ] Build a GitHub release from the latest tagged commit on `main` and add the respective section from `CHANGELOG.md` to the release notes.
+- [ ] Registration: Go to the issues and search for `Release`. There, write a comment with `<at>JuliaRegistrator register(branch="main")` with a real `@` to trigger the registration bot opening a PR on Julia's general registry. Also add a small general description of the release, so TagBot adds it to the GitHub release later.
+- [ ] Once the registration is completed, check that the TagBot correctly tagged the version and built a GitHub release.
 ```
 
 ### Releasing Breaking Changes


### PR DESCRIPTION
I set up the deploy keys and the private keys already.
I also changed the release template slightly to reflect that we no longer have to tag or publish github releases ourselves.