### PR TITLE
Skip Pkg.develop for dev package

### DIFF
--- a/.ci/SetupDevEnv/src/SetupDevEnv.jl
+++ b/.ci/SetupDevEnv/src/SetupDevEnv.jl
@@ -608,17 +608,26 @@ function install_qed_dev_packages(
     for pkg in pkg_to_install
         if pkg == dev_package_name
             @info "install dev package: $(dev_package_path)"
-            Pkg.develop(; path=dev_package_path)
-        else
-            project_path = joinpath(qed_path, pkg)
-
-            for (compat_name, compat_version) in compat_changes
-                set_compat_helper(compat_name, compat_version, project_path)
+            try
+                Pkg.develop(; path=dev_package_path)
+            catch e
+                if isa(e, LoadError)
+                    @info "already loaded, skipping"
+                else
+                    rethrow()
+                end
             end
-
-            @info "install dependency package: $(project_path)"
-            Pkg.develop(; path=project_path)
+            continue
         end
+
+        project_path = joinpath(qed_path, pkg)
+
+        for (compat_name, compat_version) in compat_changes
+            set_compat_helper(compat_name, compat_version, project_path)
+        end
+
+        @info "install dependency package: $(project_path)"
+        Pkg.develop(; path=project_path)
     end
 end
 

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ QEDbase = "0.3"
 QEDcore = "0.2"
 QEDevents = "0.1"
 QEDfields = "0.1"
-QEDprocesses = "0.2"
+QEDprocesses = "0.3"
 Reexport = "^1.2"
 julia = "1.10"
 


### PR DESCRIPTION
This simply skips the `Pkg.develop` call for the package that is currently being developed. Trying to load it results in `ERROR: LoadError: package `QEDbase [10e22c08]` has the same name or UUID as the active project`, see for example  https://gitlab.com/hzdr/qedjl-project/QEDbase-jl/-/pipelines/1518348313 . I'm not 100% sure this is the correct fix for the problem, please correct if I'm wrong @SimeonEhrig .

I made two test runs in base and core with this branch
QEDbase: https://gitlab.com/hzdr/qedjl-project/QEDbase-jl/-/pipelines/1521645744
QEDcore: https://gitlab.com/hzdr/qedjl-project/qedcore.jl/-/pipelines/1521655755

And both seem to work fine.

Edit: Changed it so that it tries to install the dev package and catches the `LoadError`.