### PR TITLE
SetupDevEnv: do not (un-)install dependency if the dependency is the name of the active package environment

### DIFF
--- a/.ci/SetupDevEnv/src/SetupDevEnv.jl
+++ b/.ci/SetupDevEnv/src/SetupDevEnv.jl
@@ -562,7 +562,15 @@ Remove the given packages from the active environment.
 """
 function remove_packages(dependencies::Vector{String})
     @info "remove packages: $(dependencies)"
+    project_pkg_name = Pkg.project().name
+
     for pkg in dependencies
+        if pkg == project_pkg_name
+            @warn "Skipped uninstallation: Try to uninstall the dependency $(pkg), " *
+                "but it is the name of the active project."
+            continue
+        end
+
         # if the package is in the extra section, it cannot be removed
         try
             Pkg.rm(pkg)
@@ -605,7 +613,15 @@ function install_qed_dev_packages(
 )
     @info "install QED packages"
 
+    project_pkg_name = Pkg.project().name
+
     for pkg in pkg_to_install
+        if pkg == project_pkg_name
+            @warn "Skipped installation: Try to install the dependency $(pkg), " *
+                "but it is the name of the active project."
+            continue
+        end
+
         if pkg == dev_package_name
             @info "install dev package: $(dev_package_path)"
             Pkg.develop(; path=dev_package_path)

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ QEDbase = "0.3"
 QEDcore = "0.2"
 QEDevents = "0.1"
 QEDfields = "0.1"
-QEDprocesses = "0.2"
+QEDprocesses = "0.3"
 Reexport = "^1.2"
 julia = "1.10"
 


### PR DESCRIPTION
Here you find a PR which tests this fix: https://github.com/QEDjl-project/QEDbase.jl/pull/136