### PR TITLE
add command line arguments to Bootloader.jl

### DIFF
--- a/.ci/CI/Project.toml
+++ b/.ci/CI/Project.toml
@@ -4,6 +4,7 @@ authors = ["Simeon Ehrig <s.ehrig@hzdr.de>"]
 version = "0.1.0"
 
 [deps]
+ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 IntegrationTests = "6be7cfa2-1838-408e-bc49-3a824ac3a1fb"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
@@ -14,6 +15,7 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
+ArgParse = "1.2.0"
 julia = "1"
 
 [extras]

--- a/.ci/CI/src/Bootloader.jl
+++ b/.ci/CI/src/Bootloader.jl
@@ -7,20 +7,232 @@ using IntegrationTests
 using TOML
 using Logging
 using YAML
+using ArgParse
 
 """
-    _check_env_vars()
+    parse_commandline()::Dict{String, Any}
 
-Check if required environemnt variables are set. Exit with error, if not set.
+# Return
+
+Parsed script arguments.
 """
-function _check_env_vars()
-    if !haskey(ENV, "CI_COMMIT_REF_NAME")
-        @error "Environment variable CI_COMMIT_REF_NAME is not set. Required to determine target branch."
+function parse_commandline()::Dict{String,Any}
+    s = ArgParseSettings()
+
+    @add_arg_table s begin
+        "--nocpu"
+        help = "Disable the generation of CPU tests."
+        action = :store_true
+        "--cuda"
+        help = "Enable the generation of CUDA tests."
+        action = :store_true
+        "--amdgpu"
+        help = "Enable the generation of AMDGPU tests."
+        action = :store_true
+        "--target-branch"
+        help = "If target branch is set, does not read the target branch from a GitHub Pull Request which is set via environment variable `CI_COMMIT_REF_NAME`."
+        arg_type = String
+        "--project-path"
+        help = "Set the path to the package folder of the package to be tested. Can also be set via the environment variable `CI_PROJECT_DIR`."
+        arg_type = String
     end
 
-    if !haskey(ENV, "CI_PROJECT_DIR")
-        @error "Environment variable CI_PROJECT_DIR is not set. Defines the base path of the project to test."
+    return parse_args(s)
+end
+
+"""
+    _get_config_from_arg_or_env_variable(
+        arg_name::AbstractString,
+        env_name::AbstractString,
+        error_msg::AbstractString,
+        args::Dict{String,Any},
+    )::String
+
+Checks the script argument and the environment variable. If the script argument is set, the value
+is returned. If the argument is not set, the environment variable is checked and its value is 
+returned. If both are not set, an error message is displayed and the program is terminated with 
+error code 1.
+
+# Args
+- `arg_name::AbstractString`: Name of the argument.
+- `env_name::AbstractString`: Name of the environment variable.
+- `error_msg::AbstractString`: Error message if both are not set.
+- `args::Dict{String,Any}`: Parsed arguments
+
+# Return
+
+Ether the value of the argument or the environment variable.
+"""
+function _get_config_from_arg_or_env_variable(
+    arg_name::AbstractString,
+    env_name::AbstractString,
+    error_msg::AbstractString,
+    args::Dict{String,Any},
+)::String
+    if args[arg_name] !== nothing
+        return args[arg_name]
     end
+
+    if haskey(ENV, env_name)
+        return ENV[env_name]
+    end
+
+    @error error_msg
+    return exit(1)
+end
+
+"""
+    get_target_branch(args::Dict{String,Any})::String
+
+Get the target branch name. Can be set via argument `--target-branch` or environment variable
+`CI_COMMIT_REF_NAME`.
+
+# Args
+- `args::Dict{String,Any}`: Parsed arguments
+
+# Return
+
+Target branch name.
+"""
+function get_target_branch(args::Dict{String,Any})::String
+    ci_commit_ref_name = _get_config_from_arg_or_env_variable(
+        "target-branch",
+        "CI_COMMIT_REF_NAME",
+        "Target branch is not set via argument `--target-branch` or environment variable `CI_COMMIT_REF_NAME`",
+        args,
+    )
+
+    return find_target_branch(ci_commit_ref_name)
+end
+
+"""
+    get_project_path(args::Dict{String,Any})::String
+
+Get the path of the project to be tested. Can be set via argument `--project-path` or environment
+variable `CI_PROJECT_DIR`.
+
+# Args
+- `args::Dict{String,Any}`: Parsed arguments
+
+# Return
+
+The path of the project to be tested.
+"""
+function get_project_path(args::Dict{String,Any})::String
+    return _get_config_from_arg_or_env_variable(
+        "project-path",
+        "CI_PROJECT_DIR",
+        "Path of the package to be tested is not set via argument `--project-path` or environment variable `CI_PROJECT_DIR`",
+        args,
+    )
+end
+
+"""
+    is_cpu_tests(args::Dict{String,Any})::Bool
+
+Returns true, if CPU unit tests should be generated. CPU tests are enabled by default. Set argument
+`--nocpu` to disable it or use the environment variable `CI_ENABLE_CPU_TESTS={"ON"|"OFF"}`.
+
+# Args
+- `args::Dict{String,Any}`: Parsed arguments
+
+# Return 
+
+True, if CPU unit tests should be generated.
+"""
+function is_cpu_tests(args::Dict{String,Any})::Bool
+    # if flag is set, disable CPU tests
+    # otherwise check environment variable
+    if args["nocpu"]
+        return false
+    end
+
+    if haskey(ENV, "CI_ENABLE_CPU_TESTS")
+        if ENV["CI_ENABLE_CPU_TESTS"] == "ON"
+            return true
+        end
+        if ENV["CI_ENABLE_CPU_TESTS"] == "OFF"
+            return false
+        end
+        @error "environment variable CI_ENABLE_CPU_TESTS contains unknown value: $(ENV["CI_ENABLE_CPU_TESTS"])\n" *
+            "Only `ON` or `OFF` is allowed."
+        exit(1)
+    end
+
+    # if no argument or environment variable is set, enable CPU tests
+    return true
+end
+
+"""
+    _is_gpu_tests(
+        arg_name::AbstractString, env_name::AbstractString, args::Dict{String,Any}
+    )::Bool
+
+Return if gpu unit tests should be generated depending on a commandline argument or environment 
+variable.
+
+# Args
+- `arg_name::AbstractString`: Name of the argument.
+- `env_name::AbstractString`: Name of the environment variable.
+- `args::Dict{String,Any}`: Parsed arguments
+
+Return
+
+True if enabled or false if not. Default is false.
+"""
+function _is_gpu_tests(
+    arg_name::AbstractString, env_name::AbstractString, args::Dict{String,Any}
+)::Bool
+    if args[arg_name]
+        return true
+    end
+
+    if haskey(ENV, env_name)
+        if ENV[env_name] == "ON"
+            return true
+        end
+        if ENV[env_name] == "OFF"
+            return false
+        end
+        @error "environment variable env_name contains unknown value: $(ENV["env_name"])\n" *
+            "Only `ON` or `OFF` is allowed."
+        exit(1)
+    end
+
+    # if no argument or environment variable is set, disable GPU tests
+    return false
+end
+
+"""
+    is_cuda_tests(args::Dict{String,Any})::Bool
+
+Check if CUDA GPU unit tests should be generated.
+
+# Args
+- `args::Dict{String,Any}`: Parsed arguments
+
+# Return 
+
+True, if CUDA GPU unit tests should be generated.
+"""
+function is_cuda_tests(args::Dict{String,Any})::Bool
+    return _is_gpu_tests("cuda", "CI_ENABLE_CUDA_TESTS", args)
+end
+
+"""
+    is_amdgpu_tests(args::Dict{String,Any})::Bool
+
+Check if AMDGPU GPU unit tests should be generated.
+
+# Args
+- `args::Dict{String,Any}`: Parsed arguments
+
+# Return 
+
+True, if AMDGPU GPU unit tests should be generated.
+"""
+function is_amdgpu_tests(args::Dict{String,Any})::Bool
+    return _is_gpu_tests("amdgpu", "CI_ENABLE_AMDGPU_TESTS", args)
 end
 
 """
@@ -161,18 +373,42 @@ function print_job_yaml(job_yaml::Dict, io::IO=stdout)
     end
 end
 
+"""
+    _info_enabled_tests(test_name::AbstractString, state::Bool)
+
+Helper function to display of unit tests are generated.
+
+# Args
+- `test_name::AbstractString`: Name of the unit test category
+- `state::Bool`: Is enabled or not
+"""
+function _info_enabled_tests(test_name::AbstractString, state::Bool)
+    @info "$(test_name) unit tests are $(state ? "enabled" : "disabled")"
+end
+
 # use main function to avoid to define global variables
 function main()
-    _check_env_vars()
+    args = parse_commandline()
 
-    package_path = ENV["CI_PROJECT_DIR"]
+    target_branch = get_target_branch(args)
+    package_path = get_project_path(args)
     test_package = get_package_name_version(package_path)
-    target_branch = get_target()
 
     @info "Test package name: $(test_package.name)"
     @info "Test package version: $(test_package.version)"
     @info "Test package path: $(test_package.path)"
     @info "PR target branch: $(target_branch)"
+
+    is_cpu = is_cpu_tests(args)
+    is_cuda = is_cuda_tests(args)
+    is_amdgpu = is_amdgpu_tests(args)
+
+    _info_enabled_tests("CPU", is_cpu)
+    _info_enabled_tests("CUDA", is_cuda)
+    _info_enabled_tests("AMDGPU", is_amdgpu)
+
+    is_unit_tests = is_cpu || is_cuda || is_amdgpu
+    @info "unit tests are $(is_unit_tests ? "enabled" : "disabled")"
 
     unit_test_julia_versions = get_unit_test_julia_versions()
     @info "Julia versions for the unit tests: $(unit_test_julia_versions)"
@@ -181,17 +417,19 @@ function main()
 
     tools_git_repo = get_git_ci_tools_url_branch()
 
-    add_unit_test_job_yaml!(
-        job_yaml,
-        test_package,
-        unit_test_julia_versions,
-        target_branch,
-        CPU,
-        tools_git_repo,
-        get_unit_test_nightly_baseimage(),
-    )
+    if is_cpu
+        add_unit_test_job_yaml!(
+            job_yaml,
+            test_package,
+            unit_test_julia_versions,
+            target_branch,
+            CPU,
+            tools_git_repo,
+            get_unit_test_nightly_baseimage(),
+        )
+    end
 
-    if haskey(ENV, "CI_ENABLE_CUDA_TESTS") || haskey(ENV, "CI_ENABLE_AMDGPU_TESTS")
+    if is_cuda || is_amdgpu
         for version in ["rc", "nightly"]
             if version in unit_test_julia_versions
                 @info "Remove unit test version $(version) for GPU tests"
@@ -200,7 +438,7 @@ function main()
         end
     end
 
-    if haskey(ENV, "CI_ENABLE_CUDA_TESTS")
+    if is_cuda
         @info "Generate CUDA unit tests"
         add_unit_test_job_yaml!(
             job_yaml,
@@ -212,7 +450,7 @@ function main()
         )
     end
 
-    if haskey(ENV, "CI_ENABLE_AMDGPU_TESTS")
+    if is_amdgpu
         @info "Generate AMDGPU unit tests"
 
         add_unit_test_job_yaml!(
@@ -227,7 +465,9 @@ function main()
 
     add_integration_test_job_yaml!(job_yaml, test_package, target_branch, tools_git_repo)
 
-    add_unit_test_verify_job_yaml!(job_yaml, target_branch, tools_git_repo)
+    if is_unit_tests
+        add_unit_test_verify_job_yaml!(job_yaml, target_branch, tools_git_repo)
+    end
 
     return print_job_yaml(job_yaml)
 end

--- a/.ci/CI/src/modules/GitLabTargetBranch.jl
+++ b/.ci/CI/src/modules/GitLabTargetBranch.jl
@@ -3,39 +3,38 @@ using JSON
 using Pkg
 
 """
-    is_pull_request()::Bool
+    is_pull_request(ci_commit_ref_name::AbstractString)::Bool
 
 Checks whether the GitLab CI mirror branch was created by a GitHub pull request.
+
+# Args
+- `ci_commit_ref_name::AbstractString`: The name of the GitLab CI branch of the mirror branch of a
+    GitHub branch. The name encodes various information, e.g. whether it is a mirror branch of a 
+    pull request. See find_target_branch()
 
 # Return
     true if is a Pull Request branch, otherwise false
 """
-function is_pull_request()::Bool
-    # GitLab CI provides the environemnt variable with the following pattern
-    # # pr-<PR number>/<repo owner of the source branch>/<project name>/<source branch name> 
-    # e.g. pr-41/SimeonEhrig/QuantumElectrodynamics.jl/setDevDepDeps
-    if !haskey(ENV, "CI_COMMIT_REF_NAME")
-        error("Environment variable CI_COMMIT_REF_NAME is not set.")
-    end
-
-    return startswith(ENV["CI_COMMIT_REF_NAME"], "pr-")
+function is_pull_request(ci_commit_ref_name::AbstractString)::Bool
+    return startswith(ci_commit_ref_name, "pr-")
 end
 
 """
-    get_build_branch()::AbstractString
+    parse_non_pull_request(ci_commit_ref_name::AbstractString)::AbstractString
 
-Returns the build branch except for version tags. In this case, main is returned.
-    
+The function handles GitHub version tags. If `ci_commit_ref_name` does not target a pull request,
+it contains either the tag or the name of the target branch. If it is tagged with a version number,
+the branch main is returned, otherwise the content of `ci_commit_ref_name`.
+
+# Args
+- `ci_commit_ref_name::AbstractString`: The name of the GitLab CI branch of the mirror branch of a
+    GitHub branch. The name encodes various information, e.g. whether it is a mirror branch of a 
+    pull request. See find_target_branch()
+
 # Return
     build branch name
 """
-function get_build_branch()::AbstractString
-    if !haskey(ENV, "CI_COMMIT_REF_NAME")
-        error("Environment variable CI_COMMIT_REF_NAME is not set.")
-    end
-
-    ci_commit_ref_name = string(ENV["CI_COMMIT_REF_NAME"])
-
+function parse_non_pull_request(ci_commit_ref_name::AbstractString)::AbstractString
     try
         VersionNumber(ci_commit_ref_name)
         # branch is a version tag
@@ -46,7 +45,12 @@ function get_build_branch()::AbstractString
 end
 
 """
-    get_target_branch_pull_request()::AbstractString
+    get_target_branch_pull_request(ci_commit_ref_name::AbstractString)::AbstractString
+
+# Args
+- `ci_commit_ref_name::AbstractString`: The name of the GitLab CI branch of the mirror branch of a
+    GitHub branch. The name encodes various information, e.g. whether it is a mirror branch of a 
+    pull request. See find_target_branch()
 
 Returns the name of the target branch of the pull request. The function is required for our special
 setup where we mirror a PR from GitHub to GitLab CI. No merge request will be open on GitLab.
@@ -54,30 +58,23 @@ Instead, a feature branch will be created and the commit will be pushed. As a re
 information about the original PR. So we need to use the GitHub Rest API to get the information
 depending on the repository name and PR number.
 """
-function get_target_branch_pull_request()::AbstractString
-    # GitLab CI provides the environemnt variable with the following pattern
-    # # pr-<PR number>/<repo owner of the source branch>/<project name>/<source branch name> 
-    # e.g. pr-41/SimeonEhrig/QuantumElectrodynamics.jl/setDevDepDeps
-    if !haskey(ENV, "CI_COMMIT_REF_NAME")
-        error("Environment variable CI_COMMIT_REF_NAME is not set.")
-    end
+function get_target_branch_pull_request(ci_commit_ref_name::AbstractString)::AbstractString
+    split_commit_ref_name = split(ci_commit_ref_name, "/")
 
-    splited_commit_ref_name = split(ENV["CI_COMMIT_REF_NAME"], "/")
-
-    if (!startswith(splited_commit_ref_name[1], "pr-"))
+    if (!startswith(split_commit_ref_name[1], "pr-"))
         # fallback for unknown branches and dev branch
         return "dev"
     end
 
     # parse to Int only to check if it is a number
-    pr_number = parse(Int, splited_commit_ref_name[1][(length("pr-") + 1):end])
+    pr_number = parse(Int, split_commit_ref_name[1][(length("pr-") + 1):end])
     if (pr_number <= 0)
         error(
             "a PR number always needs to be a positive integer number bigger than 0: $pr_number",
         )
     end
 
-    repository_name = splited_commit_ref_name[3]
+    repository_name = split_commit_ref_name[3]
 
     try
         headers = (
@@ -107,18 +104,27 @@ function get_target_branch_pull_request()::AbstractString
 end
 
 """
-    get_target()::AbstractString
+    find_target_branch(ci_commit_ref_name::AbstractString)::AbstractString
 
 Return the correct target branch name for our GitLab CI mirror setup.
+
+# Args
+- `ci_commit_ref_name::AbstractString`: The name of the GitLab CI branch of the mirror branch of a
+    GitHub branch. The name encodes various information, e.g. whether it is a mirror branch of a 
+    pull request.
+
+The pattern of the branch name defined in ci_commit_ref_name is:
+pr-<PR number>/<repo owner of the source branch>/<project name>/<source branch name> 
+e.g. pr-41/SimeonEhrig/QuantumElectrodynamics.jl/setDevDepDeps
 
 # Return
 
     target branch name
 """
-function get_target()::AbstractString
-    if is_pull_request()
-        return get_target_branch_pull_request()
+function find_target_branch(ci_commit_ref_name::AbstractString)::AbstractString
+    if is_pull_request(ci_commit_ref_name)
+        return get_target_branch_pull_request(ci_commit_ref_name)
     else
-        return get_build_branch()
+        return parse_non_pull_request(ci_commit_ref_name)
     end
 end

--- a/.ci/CI/test/get_target_branch.jl
+++ b/.ci/CI/test/get_target_branch.jl
@@ -1,14 +1,6 @@
 @testset "test is_pull_request()" begin
-    @testset "no environemnt variable CI_COMMIT_REF_NAME set" begin
-        if haskey(ENV, "CI_COMMIT_REF_NAME")
-            delete!(ENV, "CI_COMMIT_REF_NAME")
-        end
-        @test_throws ErrorException CI.is_pull_request()
-    end
-
     @testset "empty CI_COMMIT_REF_NAME" begin
-        ENV["CI_COMMIT_REF_NAME"] = ""
-        @test CI.is_pull_request() == false
+        @test CI.is_pull_request("") == false
     end
 
     for (ref_name, expected_result) in (
@@ -18,20 +10,12 @@
         ("v0.1.0", false),
     )
         @testset "CI_COMMIT_REF_NAME=$(ref_name)" begin
-            ENV["CI_COMMIT_REF_NAME"] = ref_name
-            @test CI.is_pull_request() == expected_result
+            @test CI.is_pull_request(ref_name) == expected_result
         end
     end
 end
 
-@testset "test get_build_branch()" begin
-    @testset "no environemnt variable CI_COMMIT_REF_NAME set" begin
-        if haskey(ENV, "CI_COMMIT_REF_NAME")
-            delete!(ENV, "CI_COMMIT_REF_NAME")
-        end
-        @test_throws ErrorException CI.get_build_branch()
-    end
-
+@testset "test parse_non_pull_request()" begin
     for (ref_name, expected_result) in (
         (
             "pr-41/SimeonEhrig/QuantumElectrodynamics.jl/setDevDepDeps",
@@ -44,17 +28,7 @@ end
         ("feature3", "feature3"),
     )
         @testset "CI_COMMIT_REF_NAME=$(ref_name)" begin
-            ENV["CI_COMMIT_REF_NAME"] = ref_name
-            @test CI.get_build_branch() == expected_result
+            @test CI.parse_non_pull_request(ref_name) == expected_result
         end
-    end
-end
-
-@testset "test get_target_branch_pull_request()" begin
-    @testset "no environemnt variable CI_COMMIT_REF_NAME set" begin
-        if haskey(ENV, "CI_COMMIT_REF_NAME")
-            delete!(ENV, "CI_COMMIT_REF_NAME")
-        end
-        @test_throws ErrorException CI.get_target_branch_pull_request()
     end
 end


### PR DESCRIPTION
Allow to configure Bootloader.jl with command line arguments additional to environment variables.

Preparation to allow to split the unit tests in a CPU and GPU pipeline.